### PR TITLE
use base64 for cache key

### DIFF
--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -63,10 +63,13 @@ impl PublicKeyService for PublicKeyGrpc {
             Key::Secp256k1(data) => base64::encode(data),
         };
 
-        let mut cache = self.cache.lock().unwrap();
         if response.url.is_empty() {
+            let mut cache = self.cache.lock().unwrap();
+            
             cache.add_local_public_key(key);
         } else {
+            let mut cache = self.cache.lock().unwrap();
+            
             cache.add_remote_public_key(key, response.url.clone());
         }
 

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -445,7 +445,7 @@ mod tests {
         let cache = cache.lock().unwrap();
         assert_eq!(cache.local_public_keys.len(), 1);
         assert_eq!(cache.remote_public_keys.len(), 0);
-        assert!(cache.local_public_keys.contains(&std::str::from_utf8(&vec![1u8, 2u8, 3u8]).unwrap().to_owned()));
+        assert!(cache.local_public_keys.contains(&base64::encode(&vec![1u8, 2u8, 3u8])));
     }
 
     #[tokio::test]
@@ -477,6 +477,6 @@ mod tests {
         let cache = cache.lock().unwrap();
         assert_eq!(cache.local_public_keys.len(), 0);
         assert_eq!(cache.remote_public_keys.len(), 1);
-        assert!(cache.remote_public_keys.contains_key(&std::str::from_utf8(&vec![1u8, 2u8, 3u8]).unwrap().to_owned()));
+        assert!(cache.remote_public_keys.contains_key(&base64::encode(&vec![1u8, 2u8, 3u8])));
     }
 }

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -65,11 +65,11 @@ impl PublicKeyService for PublicKeyGrpc {
 
         if response.url.is_empty() {
             let mut cache = self.cache.lock().unwrap();
-            
+
             cache.add_local_public_key(key);
         } else {
             let mut cache = self.cache.lock().unwrap();
-            
+
             cache.add_remote_public_key(key, response.url.clone());
         }
 


### PR DESCRIPTION
No guarantee that the secp256k1 key bytes are actually valid utf8, I think this is the fix.

It appears that when `cache.get_public_key_state` is called for replication functionality when putting an object, that the public key for the party provided is base64 encoded, so I assume that is what it needs to be when inserting into the cache... also, the `datastore::add_public_key` method is base64 encoding the key when inserting into the db... though I'm not quite sure what mechanism is parsing the base64 from the db back into the PublicKey proto in the response...