### PR TITLE
User authorization

### DIFF
--- a/migrations/20211129141831_cleanup_public_key.sql
+++ b/migrations/20211129141831_cleanup_public_key.sql
@@ -1,6 +1,3 @@
 ALTER TABLE public_key
 	DROP COLUMN signing_public_key,
 	DROP COLUMN signing_public_key_type;
-
-ALTER TABLE public_key
-	ALTER COLUMN url DROP NOT NULL;

--- a/migrations/20211129141831_cleanup_public_key.sql
+++ b/migrations/20211129141831_cleanup_public_key.sql
@@ -1,0 +1,6 @@
+ALTER TABLE public_key
+	DROP COLUMN signing_public_key,
+	DROP COLUMN signing_public_key_type;
+
+ALTER TABLE public_key
+	ALTER COLUMN url DROP NOT NULL;

--- a/migrations/20211129141848_add_auth_public_key.sql
+++ b/migrations/20211129141848_add_auth_public_key.sql
@@ -1,0 +1,5 @@
+CREATE TYPE auth_type AS ENUM ('header');
+
+ALTER TABLE public_key
+	ADD COLUMN auth_type auth_type,
+	ADD COLUMN auth_data TEXT;

--- a/proto/public_key.proto
+++ b/proto/public_key.proto
@@ -13,24 +13,42 @@ service PublicKeyService {
     rpc Add(PublicKeyRequest) returns (PublicKeyResponse) {};
 }
 
+message HeaderAuth {
+    string header = 1;
+    string value = 2;
+}
+
 message PublicKeyRequest {
+    reserved 4;
+    reserved "signing_public_key";
+
     // public key of a party member used for encryption
     PublicKey public_key = 1;
-    // public key of a party member used for signing
-    PublicKey signing_public_key = 4;
+
     // optional - remote url of the object-store associated with the p8e public key
     // when blank, this public key is associated with the local p8e environment
     string url = 2;
+
+    // optional - used for authorization when desired
+    oneof impl {
+        HeaderAuth header_auth = 5;
+    }
+
     // optional - contains any associated metadata that the caller wants to attach
     // to this public key
     google.protobuf.Any metadata = 3;
 }
 
 message PublicKeyResponse {
+    reserved 7;
+    reserved "signing_public_key";
+
     UUID uuid = 1;
     PublicKey public_key = 2;
-    PublicKey signing_public_key = 7;
     string url = 3;
+    oneof impl {
+        HeaderAuth header_auth = 8;
+    }
     google.protobuf.Any metadata = 4;
 
     google.protobuf.Timestamp created_at = 5;

--- a/src/authorization.rs
+++ b/src/authorization.rs
@@ -1,0 +1,28 @@
+use tonic::{Status, metadata::MetadataMap};
+
+pub trait Authorization {
+    fn authorize(&self, metadata: &MetadataMap) -> Result<(), Status>;
+}
+
+#[derive(Default)]
+pub struct NoAuthorization { }
+
+impl Authorization for NoAuthorization {
+    fn authorize(&self, _: &MetadataMap) -> Result<(), Status> {
+        Err(Status::permission_denied("auth_type not configured"))
+    }
+}
+
+pub struct HeaderAuth<'a> {
+    pub header: &'a str,
+    pub value: &'a str,
+}
+
+impl Authorization for HeaderAuth<'_> {
+    fn authorize(&self, metadata: &MetadataMap) -> Result<(), Status> {
+        match metadata.get(self.header) {
+            Some(value) if value == self.value => Ok(()),
+            _ => Err(Status::permission_denied("not authorized"))
+        }
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -12,28 +12,26 @@ pub enum PublicKeyState {
 #[derive(Clone, Debug, Default)]
 pub struct Cache {
     // keys are base64 strings
-    pub local_public_keys: HashMap<String, PublicKey>,
-    // keys are base64 strings, values are (key data, url) pairs
-    pub remote_public_keys: HashMap<String, (PublicKey, String)>,
+    pub public_keys: HashMap<String, PublicKey>,
 }
 
 impl Cache {
 
-    pub fn add_local_public_key(&mut self, key: PublicKey) -> Option<PublicKey> {
-        self.local_public_keys.insert(key.public_key.clone(), key)
-    }
-
-    pub fn add_remote_public_key(&mut self, key: PublicKey, url: String) -> Option<(PublicKey, String)> {
-        self.remote_public_keys.insert(key.public_key.clone(), (key, url))
+    pub fn add_public_key(&mut self, key: PublicKey) -> Option<PublicKey> {
+        self.public_keys.insert(key.public_key.clone(), key)
     }
 
     pub fn get_public_key_state(&self, public_key: &String) -> PublicKeyState {
-        if self.local_public_keys.contains_key(public_key) {
-            PublicKeyState::Local
-        } else if self.remote_public_keys.contains_key(public_key) {
-            PublicKeyState::Remote
-        } else {
-            PublicKeyState::Unknown
+        match self.public_keys.get(public_key) {
+            Some(key) if !key.url.is_empty() => PublicKeyState::Remote,
+            Some(_) => PublicKeyState::Local,
+            None => PublicKeyState::Unknown,
         }
+    }
+
+    pub fn get_remote_public_keys(&self) -> Vec<(&String, &PublicKey)> {
+        self.public_keys.iter()
+            .filter(|(_, v)| !v.url.is_empty())
+            .collect()
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,4 +1,6 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+
+use crate::datastore::PublicKey;
 
 #[derive(Debug)]
 pub enum PublicKeyState {
@@ -10,23 +12,23 @@ pub enum PublicKeyState {
 #[derive(Clone, Debug, Default)]
 pub struct Cache {
     // keys are base64 strings
-    pub local_public_keys: HashSet<String>,
-    // keys are base64 strings, values are urls
-    pub remote_public_keys: HashMap<String, String>,
+    pub local_public_keys: HashMap<String, PublicKey>,
+    // keys are base64 strings, values are (key data, url) pairs
+    pub remote_public_keys: HashMap<String, (PublicKey, String)>,
 }
 
 impl Cache {
 
-    pub fn add_local_public_key(&mut self, public_key: String) -> bool {
-        self.local_public_keys.insert(public_key)
+    pub fn add_local_public_key(&mut self, key: PublicKey) -> Option<PublicKey> {
+        self.local_public_keys.insert(key.public_key.clone(), key)
     }
 
-    pub fn add_remote_public_key(&mut self, public_key: String, url: String) -> Option<String> {
-        self.remote_public_keys.insert(public_key, url)
+    pub fn add_remote_public_key(&mut self, key: PublicKey, url: String) -> Option<(PublicKey, String)> {
+        self.remote_public_keys.insert(key.public_key.clone(), (key, url))
     }
 
     pub fn get_public_key_state(&self, public_key: &String) -> PublicKeyState {
-        if self.local_public_keys.contains(public_key) {
+        if self.local_public_keys.contains_key(public_key) {
             PublicKeyState::Local
         } else if self.remote_public_keys.contains_key(public_key) {
             PublicKeyState::Remote

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub backoff_max_wait: i64,
     pub logging_threshold_seconds: f64,
     pub trace_header: String,
+    pub user_auth_enabled: bool,
 }
 
 const BASE_SPAN_TAGS: [(&'static str, &'static str); 3] = [
@@ -132,6 +133,10 @@ impl Config {
             .expect("LOGGING_THRESHOLD_SECONDS could not be parsed into a i32");
         let logging_threshold_seconds: f64 = logging_threshold_seconds.into();
         let trace_header = env::var("TRACE_HEADER").expect("TRACE_HEADER not set");
+        let user_auth_enabled: bool = env::var("USER_ATH_ENABLED")
+            .unwrap_or("false".to_owned())
+            .parse()
+            .expect("USER_AUTH_ENABLED could not be parsed into a bool");
 
         Self {
             url,
@@ -153,6 +158,7 @@ impl Config {
             replication_enabled,
             logging_threshold_seconds,
             trace_header,
+            user_auth_enabled,
         }
     }
 

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -190,7 +190,7 @@ mod tests {
         dime.metadata.insert(MAILBOX_KEY.to_owned(), MAILBOX_FRAGMENT_REQUEST.to_owned());
         let payload: bytes::Bytes = "fragment request envelope".as_bytes().into();
         let chunk_size = 500; // full payload in one packet
-        let response = put_helper(dime, payload, chunk_size, HashMap::default()).await;
+        let response = put_helper(dime, payload, chunk_size, HashMap::default(), Vec::default()).await;
 
         match response {
             Ok(response) => {
@@ -215,7 +215,7 @@ mod tests {
         dime.metadata.insert(MAILBOX_KEY.to_owned(), MAILBOX_FRAGMENT_RESPONSE.to_owned());
         let payload: bytes::Bytes = "fragment response envelope".as_bytes().into();
         let chunk_size = 500; // full payload in one packet
-        let response = put_helper(dime, payload, chunk_size, HashMap::default()).await;
+        let response = put_helper(dime, payload, chunk_size, HashMap::default(), Vec::default()).await;
 
         match response {
             Ok(response) => {
@@ -240,7 +240,7 @@ mod tests {
         dime.metadata.insert(MAILBOX_KEY.to_owned(), MAILBOX_ERROR_RESPONSE.to_owned());
         let payload: bytes::Bytes = "error envelope".as_bytes().into();
         let chunk_size = 500; // full payload in one packet
-        let response = put_helper(dime, payload, chunk_size, HashMap::default()).await;
+        let response = put_helper(dime, payload, chunk_size, HashMap::default(), Vec::default()).await;
 
         match response {
             Ok(response) => {
@@ -280,7 +280,7 @@ mod tests {
         let chunk_size = 500; // full payload in one packet
 
         for _ in 0..10 {
-            let response = put_helper(dime.clone(), payload.clone(), chunk_size, HashMap::default()).await;
+            let response = put_helper(dime.clone(), payload.clone(), chunk_size, HashMap::default(), Vec::default()).await;
 
             match response {
                 Ok(_) => (),
@@ -291,7 +291,7 @@ mod tests {
         dime.metadata.insert(MAILBOX_KEY.to_owned(), MAILBOX_ERROR_RESPONSE.to_owned());
 
         for _ in 0..10 {
-            let response = put_helper(dime.clone(), payload.clone(), chunk_size, HashMap::default()).await;
+            let response = put_helper(dime.clone(), payload.clone(), chunk_size, HashMap::default(), Vec::default()).await;
 
             match response {
                 Ok(_) => (),
@@ -316,7 +316,7 @@ mod tests {
 
         for _ in 0..10 {
             let payload: bytes::Bytes = uuid::Uuid::new_v4().to_hyphenated().to_string().into_bytes().into();
-            let response = put_helper(dime.clone(), payload, chunk_size, HashMap::default()).await;
+            let response = put_helper(dime.clone(), payload, chunk_size, HashMap::default(), Vec::default()).await;
 
             match response {
                 Ok(_) => (),
@@ -328,7 +328,7 @@ mod tests {
 
         for _ in 0..10 {
             let payload: bytes::Bytes = uuid::Uuid::new_v4().to_hyphenated().to_string().into_bytes().into();
-            let response = put_helper(dime.clone(), payload.clone(), chunk_size, HashMap::default()).await;
+            let response = put_helper(dime.clone(), payload.clone(), chunk_size, HashMap::default(), Vec::default()).await;
 
             match response {
                 Ok(_) => (),

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,19 +95,10 @@ async fn main() -> Result<()> {
 
     // populate initial cache
     for key in datastore::get_all_public_keys(&pool).await? {
-        if key.url.is_empty() {
-            log::trace!("Adding local public key - {}", &key.public_key);
+        log::debug!("Adding public key {} with url {}", &key.public_key, &key.url);
 
-            cache.add_local_public_key(key);
-        } else {
-            log::trace!("Adding remote public key - {} {}", &key.public_key, &key.url);
-
-            let url = key.url.clone();
-            cache.add_remote_public_key(key, url);
-        }
+        cache.add_public_key(key);
     }
-
-    log::debug!("Seeded public keys - remote: {} local: {}", cache.remote_public_keys.len(), cache.local_public_keys.len());
 
     let pool = Arc::new(pool);
     let cache = Arc::new(Mutex::new(cache));

--- a/src/object.rs
+++ b/src/object.rs
@@ -164,7 +164,7 @@ impl ObjectService for ObjectGrpc {
 
             match cache.get_public_key_state(&owner_public_key) {
                 PublicKeyState::Local => {
-                    if let Some(cached_key) = cache.local_public_keys.get(&owner_public_key) {
+                    if let Some(cached_key) = cache.public_keys.get(&owner_public_key) {
                         cached_key.auth()?.authorize(&metadata)
                     } else {
                         Err(Status::internal("this should not happen - key was resolved to Local state and then could not be fetched"))
@@ -356,7 +356,7 @@ pub mod tests {
 
         tokio::spawn(async move {
             let mut cache = Cache::default();
-            cache.add_local_public_key(PublicKey {
+            cache.add_public_key(PublicKey {
                 uuid: uuid::Uuid::default(),
                 public_key: std::str::from_utf8(&party_1().0.public_key).unwrap().to_owned(),
                 public_key_type: KeyType::Secp256k1,
@@ -367,20 +367,17 @@ pub mod tests {
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
             });
-            cache.add_remote_public_key(
-                PublicKey {
-                    uuid: uuid::Uuid::default(),
-                    public_key: std::str::from_utf8(&party_2().0.public_key).unwrap().to_owned(),
-                    public_key_type: KeyType::Secp256k1,
-                    url: String::from("tcp://party2:8080"),
-                    metadata: Vec::default(),
-                    auth_type: Some(AuthType::Header),
-                    auth_data: Some(String::from("x-test-header:test_value")),
-                    created_at: Utc::now(),
-                    updated_at: Utc::now(),
-                },
-                String::from("tcp://party2:8080"),
-            );
+            cache.add_public_key(PublicKey {
+                uuid: uuid::Uuid::default(),
+                public_key: std::str::from_utf8(&party_2().0.public_key).unwrap().to_owned(),
+                public_key_type: KeyType::Secp256k1,
+                url: String::from("tcp://party2:8080"),
+                metadata: Vec::default(),
+                auth_type: Some(AuthType::Header),
+                auth_data: Some(String::from("x-test-header:test_value")),
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            });
             let cache = Mutex::new(cache);
             let config = default_config.unwrap_or(test_config());
             let url = config.url.clone();


### PR DESCRIPTION
Adds a header based authorization scheme. There will soon be a follow up PR that adds a second PUT object RPC that will be dedicated for replication and have a separate authorization mechanism.

This header based authorization scheme works by allowing an API gateway to provide authentication and then forward headers to object store. The authorization is provided by matching the header key/value pair to the value associated with the DIME owner's public key. A configuration parameter is provided to enable or disable this functionality.