### PR TITLE
Bumps rust version used in docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.57 as builder
+FROM rust:1.65 as builder
 
 RUN rustup component add rustfmt
 


### PR DESCRIPTION
Moves to a MRV that supports the env_logger dependency.