### PR TITLE
chore: Upgrade and Fix CI Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - chore/upgrade-gha
   pull_request:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,22 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - run: rustup update stable && rustup default stable
-      - run: cargo build --verbose
-      - run: cargo test --verbose
-      - run: cargo fmt --workspace -- --check
+      - name: Checkout Repository
+        id: checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Rust
+        id: setup-rust
+        run: rustup update stable && rustup default stable && rustup component add rustfmt clippy
+
+      - name: Build
+        id: build
+        run: cargo build --verbose
+
+      - name: Test
+        id: test
+        run: cargo test --verbose
+
+      - name: Lint
+        id: lint
+        run: cargo fmt --workspace -- --check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - chore/upgrade-gha
   pull_request:
     branches:
       - main
@@ -14,42 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-
-          # fmt:
-          #   name: Test
-          #   runs-on: ubuntu-latest
-          #   steps:
-          #     - uses: actions/checkout@v2
-          #     - uses: actions-rs/toolchain@v1
-          #       with:
-          #         profile: minimal
-          #         toolchain: stable
-          #         override: true
-          #     - uses: actions-rs/cargo@v1
-          #       with:
-          #         command: test
-
-          # clippy:
-          #   name: Test
-          #   runs-on: ubuntu-latest
-          #   steps:
-          #     - uses: actions/checkout@v2
-          #     - uses: actions-rs/toolchain@v1
-          #       with:
-          #         profile: minimal
-          #         toolchain: stable
-          #         override: true
-          #     - uses: actions-rs/cargo@v1
-          #       with:
-          #         command: test
+      - run: rustup update stable && rustup default stable
+      - run: cargo build --verbose
+      - run: cargo test --verbose
+      - run: cargo fmt --workspace -- --check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,10 @@ jobs:
         id: test
         run: cargo test --verbose
 
-      - name: Lint
+      - name: Check formatting
+        id: check-formatting
+        run: cargo fmt --check
+
+      - name: Run linter
         id: lint
-        run: cargo fmt --workspace -- --check
+        run: cargo clippy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Version
         run: |
           # strip git ref prefix from version


### PR DESCRIPTION
## Context
Build for #27 failed. All actions used had an upgrade available or were stale. With `cargo fmt` run in #27, this PR also adds a step in the `build` action to lint the code via `cargo fmt --check`

[actions-rs/toolchain](https://github.com/actions-rs/toolchain) is stale and while there are some alternatives, Ubuntu images have [rust tools included](https://github.com/actions/runner-images/blob/665cb1d7a94a26b94df746f7a2976fb28690d095/images/ubuntu/Ubuntu2404-Readme.md#rust-tools), so no complex setup is needed to run `cargo` commands. ([Example](https://doc.rust-lang.org/cargo/guide/continuous-integration.html) from rust docs)

## Changes
- `actions/checkout` upgraded from `v4` to `v5`
- Replace stale rust toolchain action with direct calls to included rust tools on image
- Add fmt and lint check