### PR TITLE
feat: Use rust-toolchain.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Setup Rust
         id: setup-rust
-        run: rustup update stable && rustup default stable && rustup component add rustfmt clippy
+        run: rustup show
 
       - name: Build
         id: build

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.65"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Context
Dockerfile pinned a rust version, but using `rustup default stable` on ubuntu runners would use latest, mismatched version

## Changes
- Create and configure `rust-toolchain.toml` file