### PR TITLE
fix: Upgrade rust builder image (and toolchain)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.65 AS builder
+FROM rust:1.81-bookworm AS builder
 
 RUN rustup component add rustfmt
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.65"
+channel = "1.81"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Context
Builder image should be Debian bookworm, too (match #33)

## Changes
- Upgrade to a new Rust version still part of `2021` edition
- Use image that matches debian version