### PR TITLE
chore: add indices to improve object queries

### DIFF
--- a/migrations/20260108111601_create_object_metadata_index.sql
+++ b/migrations/20260108111601_create_object_metadata_index.sql
@@ -1,0 +1,4 @@
+-- no-transaction
+CREATE INDEX CONCURRENTLY object_metadata_idx
+    ON object(created_at, content_length)
+    WHERE directory <> 'NOT_STORAGE_BACKED';

--- a/migrations/20260108111602_create_object_public_key_index.sql
+++ b/migrations/20260108111602_create_object_public_key_index.sql
@@ -1,0 +1,3 @@
+-- no-transaction
+CREATE INDEX CONCURRENTLY object_public_key_public_key_idx
+    ON object_public_key(public_key);

--- a/migrations/20260108111603_create_object_replicated_at_index.sql
+++ b/migrations/20260108111603_create_object_replicated_at_index.sql
@@ -1,0 +1,3 @@
+-- no-transaction
+CREATE INDEX CONCURRENTLY object_replication_status_idx
+    ON object_replication(object_uuid, public_key, replicated_at);

--- a/migrations/20260108111604_create_object_replication_status_index.sql
+++ b/migrations/20260108111604_create_object_replication_status_index.sql
@@ -1,0 +1,4 @@
+-- no-transaction
+CREATE INDEX CONCURRENTLY object_replication_replicated_at_idx
+    ON object_replication(replicated_at)
+    WHERE replicated_at is not null;


### PR DESCRIPTION
## Context
To help with external tools, several indices are needed to make queries performance enough to complete. 4 new indices created

## Changes
- `object_metadata_idx` to query for storage-backed objects by date and size
- `object_public_key_public_key_idx` to find all objects for a `public_key`
- `object_replication_status_idx` compound replication status index
- `object_replication_replicated_at_idx` to query by replicated date