### PR TITLE
chore: Upgrade Rust Toolchain to 1.97

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92"
+channel = "1.97"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Context
Stay up to date with [latest Rust version](https://releases.rs/docs/1.97.0/)

## Changes
- Update toolchain version (`1.92 -> 1.97`)